### PR TITLE
Remover hook de teste

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "npm test"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Esse hook tinha um comportamento indesejado - as vezes nós queremos pushar as mudanças mesmo que os testes não estejam passando.